### PR TITLE
Initial Feedback

### DIFF
--- a/standard_node_naming_convention.md
+++ b/standard_node_naming_convention.md
@@ -1,45 +1,30 @@
 # Standard Node Naming Convention
 
-#### It should be :
+## Goals
 
-* **Logical**
-  - It is important to remember that host names should not reflect a specific device, but rather, 
-    be a logical identifier of a device in the overarching infrastructure. 
-    This allows for schemes to be teleported across environments.
+**Logical**: It is important to remember that host names should not reflect a specific device, but rather,  be a logical identifier of a device in the overarching infrastructure. This allows for schemes to be teleported across environments.
 
-* **Scalable**
-  - The scheme must be able to scale, accommodating not just growth, but also shrinkage.
+**Scalable**: The scheme must be able to scale, accommodating not just growth, but also shrinkage.
 
-* **Human Readable**
-  - The scheme must be readable and descriptive enough for a Human to consult a site-book 
-    for further documentation about the object(s).
+**Human Readable**: The scheme must be readable and descriptive enough for a Human to consult a site-book for further documentation about the object(s).
 
-* **Machine Readable**
-  - The scheme must remain easily parse-able and dynamically generate-able 
-    by a machine for automation purposes.
+**Machine Readable**: The scheme must remain easily parse-able and dynamically generate-able by a machine for automation purposes.
 
-* **Authoritative**
-  - Identifiers such as locations, or VLAN tags must always match with 
-    an authoritative source, such as a site-book.
+**Authoritative**: Identifiers such as locations, or VLAN tags must always match with an authoritative source, such as a site-book.
 
 #### Furthermore :
-* The DNS hierarchy should always properly reflect the naming scheme. 
-  In the event that a specific service on a host should need to be referenced, 
-  a CNAME record shall be used.
-
-
+* The DNS hierarchy should always properly reflect the naming scheme. In the event that a specific service on a host should need to be referenced, a CNAME record shall be used.
 
 
 ## Network Devices and Interfaces
 
 ### Physical Chassis
 
-* [type]-[layer]-[serial]
+* `[type]-[layer]-[serial]`
 
 For example, a redundant distribution switch on a campus could be named the following.
 
-* sw-ds-02.bldg4.campus02.example.com
-
+* `sw-ds-02.bldg4.campus02.example.com`
 
 #### Example References:
 
@@ -61,15 +46,14 @@ For example, a redundant distribution switch on a campus could be named the foll
 
 
 ### Interfaces Descriptions
- 
-* [type]-[serial]--[destint]-[desthost] 
 
-For example, a trunk interface for vlan 20 from an edge router (rt-eg-01.campus.example.com) 
-to a core switch could look like the following.
+* `[type]-[serial]--[destint]-[desthost]`
 
-* vl20--ge01.sw-co-01.campus.example.com
+For example, a trunk interface for VLAN 20 from an edge router (rt-eg-01.campus.example.com) to a core switch could look like the following.
 
-This is especially usefull for long P2P links, such as GRE, VPN or building interconnects. 
+* `vl20--ge01.sw-co-01.campus.example.com`
+
+This is especially useful for long P2P links, such as GRE, VPN or building interconnects.
 
 
 #### Example References:
@@ -86,11 +70,11 @@ This is especially usefull for long P2P links, such as GRE, VPN or building inte
 
 ## Servers and Endpoints
 
-[type]-[layer]-[service/servicegroup]-[serial]  
+`[type]-[layer]-[service/servicegroup]-[serial]`
 
 For example, a server that was a host for development docker containers could be named the following:
 
-* sv-dev-docker-01
+* `sv-dev-docker-01`
 
 The service may be explicit or denoted by a generic group if it is part of a larger groups of services, such as a failover cluster.  
 
@@ -120,6 +104,3 @@ The service may be explicit or denoted by a generic group if it is part of a lar
 | Apache          |  Apache Server |
 | dns        |  Generic DNS |
 | bind          | Bind DNS Server |
-
-
-


### PR DESCRIPTION
This PR just makes some markdown formatting updates. Lines of text that make up a paragraph should be on a single line and your editor should use soft wraps. This allows a diff to show how a line of text changed nicely (instead of a block of text which may get moved around). 

Some general feedback:
I think the convention is heavy on the network aspect of naming (which is good) but light on the host and service side of things. I'll defer to your expertise on physical network naming since I don't do much of that.

Next steps would be a treatment of hierarchy. You do a bit of this with `campus02.example.com` This would help a reader determine what information to encode in a hostname (short name) versus the fully-qualified name. Some things to consider here would be on-premise vs cloud environments and if they should differ in convention. Deployment environments (prod, dev/development, stage, etc).

You want to find a balance between
`sv-prod-esxi-01.prod-east.lga.merged-business.companycom` which has a few things wrong with it, and the bare-minimum of `esxi1.example.com`

For the first production esxi server that lives in zone A of a cloud provider's us-east1 region which name is best?

* `sv-prod-esxi-01a.us-east1.company.com`
* `sv-esxi-01a.us-east1.company.com`

Other questions: do you increment the serial within a zone? within a region?

A naming convention I am stuck with now is:
`prod-us-east1-servicename-instance-zx8r.c.company-us-east1-production.internal`

There is a lot of redundant information here. I would not encode environment and region in the short-name if its encoded further up in the hierarchy (project name). Since this is GCP, the `c` part stands for Compute. I have no control over `internal`.

At the very least your discussion of hierarchy should cover whether to include the environment (prod/dev) and physical location (us-east1, or airport codes as cloudfront does)  in the host short-name, or the DNS FQDN.

Also realize that a lot of metadata that you want to encode in a hostname can often be keyed in as tags in most cloud and virtualization platforms. So there's a decision there about what to include in the hostname, fqdn, or metadata.

In a cloud environment I try to mirror what the API names are for each region/zone in whatever naming I'm doing - this makes it easy to programmatically construct names, and keeps the surprises down.

---

I used to follow this standard a while ago (https://mnx.io/blog/a-proper-server-naming-scheme/)  but became frustrated with their obsession over abbreviating all names to 3 chars. You may want to read it through for some ideas.